### PR TITLE
Add support for Ruby >= 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-pkg
 *.iml
 *.ipr
 *.iws

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ When the inbound message notification is pushed to your server as a HTTP POST re
     inbound_messages = OneApi::SmsClient.unserialize_inbound_messages(http_body)
 
 
+How to run unit tests?
+-------
+
+```sh
+rake
+```
+
+
 License
 -------
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
 
 Rake::TestTask.new do |t|
   t.libs << 'test'

--- a/examples/example_customer_profile.rb
+++ b/examples/example_customer_profile.rb
@@ -22,8 +22,8 @@ puts password
 
 customer_profile_client = OneApi::CustomerProfileClient.new(username, password)
 
-customer_profile = customer_profile_client.get_customer_profile()
+customer_profile = customer_profile_client.get_customer_profile
 puts customer_profile.inspect
 
-account_balance = customer_profile_client.get_account_balance()
+account_balance = customer_profile_client.get_account_balance
 puts account_balance.inspect

--- a/examples/example_get_inbound_messages.rb
+++ b/examples/example_get_inbound_messages.rb
@@ -20,7 +20,7 @@ end
 sms_client = OneApi::SmsClient.new(username, password)
 
 # example:retrieve-inbound-messages
-result = sms_client.retrieve_inbound_messages()
+result = sms_client.retrieve_inbound_messages
 # ----------------------------------------------------------------------------------------------------
 
 puts result.inspect

--- a/lib/oneapi-ruby/client.rb
+++ b/lib/oneapi-ruby/client.rb
@@ -41,7 +41,7 @@ module OneApi
 
             is_success, result = execute_POST('/1/customerProfile/login', params)
 
-            return fill_oneapi_authentication(result, is_success)
+            fill_oneapi_authentication(result, is_success)
         end
 
         def get_or_create_client_correlator(client_correlator=nil)
@@ -49,7 +49,7 @@ module OneApi
                 return client_correlator
             end
 
-            return Utils.get_random_alphanumeric_string
+            Utils.get_random_alphanumeric_string
         end
 
         def prepare_headers(request)
@@ -85,7 +85,7 @@ module OneApi
                 result += URI::DEFAULT_PARSER.escape(key.to_s) + '=' + URI::DEFAULT_PARSER.escape(params[key].to_s)
             end
 
-            return result
+            result
         end
 
         def execute_GET(url, params=nil)
@@ -123,7 +123,7 @@ module OneApi
             response = http.request(request)
             puts "response = #{response.body}"
 
-            return is_success(response), response.body
+            [is_success(response), response.body]
         end
 
         def get_rest_url(rest_path)
@@ -222,7 +222,7 @@ module OneApi
                     params
             )
 
-            return convert_from_json(DeliveryInfoList, result, !is_success)
+            convert_from_json(DeliveryInfoList, result, !is_success)
         end
 
         def retrieve_inbound_messages(max_number=nil)
@@ -239,7 +239,7 @@ module OneApi
                     params
             )
 
-            return convert_from_json(InboundSmsMessages, result, ! is_success)
+            convert_from_json(InboundSmsMessages, result, ! is_success)
         end
 
         # To be used when http push with a delivery notification comes.
@@ -280,9 +280,9 @@ module OneApi
 
             if Utils.empty(notify_url)
                 json = JSONUtils.get_json(result)
-                return convert_from_json(TerminalRoamingStatus, json['roaming'], ! is_success);
+                convert_from_json(TerminalRoamingStatus, json['roaming'], ! is_success);
             else
-                return convert_from_json(GenericObject, {}, ! is_success);
+                convert_from_json(GenericObject, {}, ! is_success);
             end
         end
 
@@ -302,14 +302,14 @@ module OneApi
 
         def get_account_balance
             is_success, result = execute_GET('/1/customerProfile/balance')
-            
-            return convert_from_json(AccountBalance, result, ! is_success)
+
+            convert_from_json(AccountBalance, result, ! is_success)
         end
 
         def get_customer_profile
             is_success, result = execute_GET('/1/customerProfile')
 
-            return convert_from_json(CustomerProfile, result, ! is_success)
+            convert_from_json(CustomerProfile, result, ! is_success)
         end
 
     end

--- a/lib/oneapi-ruby/client.rb
+++ b/lib/oneapi-ruby/client.rb
@@ -33,7 +33,7 @@ module OneApi
         end
 
 
-        def login()
+        def login
             params = {
                     'username' => @username,
                     'password' => @password,
@@ -49,7 +49,7 @@ module OneApi
                 return client_correlator
             end
 
-            return Utils.get_random_alphanumeric_string()
+            return Utils.get_random_alphanumeric_string
         end
 
         def prepare_headers(request)
@@ -171,7 +171,7 @@ module OneApi
         def send_sms(sms)
             client_correlator = sms.client_correlator
             if not client_correlator
-                client_correlator = Utils.get_random_alphanumeric_string()
+                client_correlator = Utils.get_random_alphanumeric_string
             end
 
             params = {
@@ -300,13 +300,13 @@ module OneApi
             super(username, password, base_url)
         end
 
-        def get_account_balance()
+        def get_account_balance
             is_success, result = execute_GET('/1/customerProfile/balance')
             
             return convert_from_json(AccountBalance, result, ! is_success)
         end
 
-        def get_customer_profile()
+        def get_customer_profile
             is_success, result = execute_GET('/1/customerProfile')
 
             return convert_from_json(CustomerProfile, result, ! is_success)

--- a/lib/oneapi-ruby/client.rb
+++ b/lib/oneapi-ruby/client.rb
@@ -280,9 +280,9 @@ module OneApi
 
             if Utils.empty(notify_url)
                 json = JSONUtils.get_json(result)
-                convert_from_json(TerminalRoamingStatus, json['roaming'], ! is_success);
+                convert_from_json(TerminalRoamingStatus, json['roaming'], ! is_success)
             else
-                convert_from_json(GenericObject, {}, ! is_success);
+                convert_from_json(GenericObject, {}, ! is_success)
             end
         end
 

--- a/lib/oneapi-ruby/client.rb
+++ b/lib/oneapi-ruby/client.rb
@@ -75,14 +75,14 @@ module OneApi
                 return ''
             end
             if params.instance_of? String
-                return URI.encode(params)
+                return URI::DEFAULT_PARSER.escape(params)
             end
             result = ''
             params.each_key do |key|
                 if ! Utils.empty(result)
                     result += '&'
                 end
-                result += URI.encode(key.to_s) + '=' + URI.encode(params[key].to_s)
+                result += URI::DEFAULT_PARSER.escape(key.to_s) + '=' + URI::DEFAULT_PARSER.escape(params[key].to_s)
             end
 
             return result
@@ -98,7 +98,7 @@ module OneApi
 
         def execute_request(http_method, url, params)
             rest_url = get_rest_url(url)
-            uri = URI(URI.encode(rest_url))
+            uri = URI(URI::DEFAULT_PARSER.escape(rest_url))
 
             if Utils.empty(params)
                 params = {}

--- a/lib/oneapi-ruby/models.rb
+++ b/lib/oneapi-ruby/models.rb
@@ -8,10 +8,10 @@ module OneApi
 
     class OneApiAuthentication < OneApiModel
 
-        oneapi_attr_accessor :username, FieldConversionRule.new()
-        oneapi_attr_accessor :password, FieldConversionRule.new()
+        oneapi_attr_accessor :username, FieldConversionRule.new
+        oneapi_attr_accessor :password, FieldConversionRule.new
         oneapi_attr_accessor :ibsso_token, FieldConversionRule.new('login.ibAuthCookie | TODO')
-        oneapi_attr_accessor :authenticated, FieldConversionRule.new()
+        oneapi_attr_accessor :authenticated, FieldConversionRule.new
         oneapi_attr_accessor :verified, FieldConversionRule.new('login.verified | TODO')
 
     end
@@ -47,11 +47,11 @@ module OneApi
 
         oneapi_attr_accessor :sender_address, FieldConversionRule.new(:senderAddress)
         oneapi_attr_accessor :sender_name, FieldConversionRule.new(:senderName)
-        oneapi_attr_accessor :message, FieldConversionRule.new()
-        oneapi_attr_accessor :address, FieldConversionRule.new()
+        oneapi_attr_accessor :message, FieldConversionRule.new
+        oneapi_attr_accessor :address, FieldConversionRule.new
         oneapi_attr_accessor :client_correlator, FieldConversionRule.new(:clientCorrelator)
         oneapi_attr_accessor :notify_url, FieldConversionRule.new(:notifyUrl)
-        oneapi_attr_accessor :callback_data, FieldConversionRule.new()
+        oneapi_attr_accessor :callback_data, FieldConversionRule.new
         oneapi_attr_accessor :language, ObjectFieldConverter.new(Language,'language')
 
     end
@@ -121,7 +121,7 @@ module OneApi
     class TerminalRoamingStatus < OneApiModel
 
         oneapi_attr_accessor :servingMccMnc, ObjectFieldConverter.new(ServingMccMnc, 'servingMccMnc')
-        oneapi_attr_accessor :address, FieldConversionRule.new()
+        oneapi_attr_accessor :address, FieldConversionRule.new
         oneapi_attr_accessor :currentRoaming, FieldConversionRule.new('currentRoaming')
         oneapi_attr_accessor :resourceURL, FieldConversionRule.new('resourceURL')
         oneapi_attr_accessor :retrievalStatus, FieldConversionRule.new('retrievalStatus')
@@ -144,19 +144,19 @@ module OneApi
 
     class CustomerProfile < OneApiModel
 
-        oneapi_attr_accessor :id, FieldConversionRule.new()
-        oneapi_attr_accessor :username, FieldConversionRule.new()
-        oneapi_attr_accessor :forename, FieldConversionRule.new()
-        oneapi_attr_accessor :surname, FieldConversionRule.new()
-        oneapi_attr_accessor :street, FieldConversionRule.new()
-        oneapi_attr_accessor :city, FieldConversionRule.new()
+        oneapi_attr_accessor :id, FieldConversionRule.new
+        oneapi_attr_accessor :username, FieldConversionRule.new
+        oneapi_attr_accessor :forename, FieldConversionRule.new
+        oneapi_attr_accessor :surname, FieldConversionRule.new
+        oneapi_attr_accessor :street, FieldConversionRule.new
+        oneapi_attr_accessor :city, FieldConversionRule.new
         oneapi_attr_accessor :zip_code, FieldConversionRule.new('zipCode')
-        oneapi_attr_accessor :telephone, FieldConversionRule.new()
-        oneapi_attr_accessor :gsm, FieldConversionRule.new()
-        oneapi_attr_accessor :fax, FieldConversionRule.new()
-        oneapi_attr_accessor :email, FieldConversionRule.new()
-        oneapi_attr_accessor :msn, FieldConversionRule.new()
-        oneapi_attr_accessor :skype, FieldConversionRule.new()
+        oneapi_attr_accessor :telephone, FieldConversionRule.new
+        oneapi_attr_accessor :gsm, FieldConversionRule.new
+        oneapi_attr_accessor :fax, FieldConversionRule.new
+        oneapi_attr_accessor :email, FieldConversionRule.new
+        oneapi_attr_accessor :msn, FieldConversionRule.new
+        oneapi_attr_accessor :skype, FieldConversionRule.new
         oneapi_attr_accessor :country_id, FieldConversionRule.new('countryId')
         oneapi_attr_accessor :timezone_id, FieldConversionRule.new('timezoneId')
         oneapi_attr_accessor :primary_language_id, FieldConversionRule.new('primaryLanguageId')
@@ -166,23 +166,23 @@ module OneApi
 
     class Currency < OneApiModel
 
-        oneapi_attr_accessor :id, FieldConversionRule.new()
+        oneapi_attr_accessor :id, FieldConversionRule.new
         oneapi_attr_accessor :currency_name, FieldConversionRule.new('currencyName')
-        oneapi_attr_accessor :symbol, FieldConversionRule.new()
+        oneapi_attr_accessor :symbol, FieldConversionRule.new
 
     end
 
     class Currency < OneApiModel
 
-        oneapi_attr_accessor :id, FieldConversionRule.new()
+        oneapi_attr_accessor :id, FieldConversionRule.new
         oneapi_attr_accessor :currency_name, FieldConversionRule.new('currencyName')
-        oneapi_attr_accessor :symbol, FieldConversionRule.new()
+        oneapi_attr_accessor :symbol, FieldConversionRule.new
 
     end
 
     class AccountBalance < OneApiModel
 
-        oneapi_attr_accessor :balance, FieldConversionRule.new()
+        oneapi_attr_accessor :balance, FieldConversionRule.new
         oneapi_attr_accessor :currency, ObjectFieldConverter.new(Currency)
 
     end

--- a/lib/oneapi-ruby/objects.rb
+++ b/lib/oneapi-ruby/objects.rb
@@ -40,7 +40,7 @@ module OneApi
                 return nil
             end
 
-            return Conversions.from_json(@classs, value, is_error=nil)
+            Conversions.from_json(@classs, value, is_error=nil)
         end
 
         def to_json(value)
@@ -68,7 +68,7 @@ module OneApi
                 result.push(Conversions.from_json(@classs, value, is_error=nil))
             end
 
-            return result
+            result
         end
 
         def to_json(value)
@@ -190,7 +190,7 @@ module OneApi
         end
 
         def is_success
-            return @exception == nil
+            @exception == nil
         end
 
     end

--- a/lib/oneapi-ruby/objects.rb
+++ b/lib/oneapi-ruby/objects.rb
@@ -102,7 +102,7 @@ module OneApi
 	class PartOfUrlFieldConversionRule < FieldConversionRule
         def initialize(json_field_name=nil, part_index=nil)
             super(json_field_name)
-			@part_index = part_index;
+			@part_index = part_index
         end
 
         def from_json(value)

--- a/lib/oneapi-ruby/utils.rb
+++ b/lib/oneapi-ruby/utils.rb
@@ -149,7 +149,7 @@ module OneApi
                     body += line + "\n"
                 end
             end
-            return method, url, headers, body.strip
+            [method, url, headers, body.strip]
         end
 
     end

--- a/oneapi-ruby.gemspec
+++ b/oneapi-ruby.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "minitest", "= 5.25.1"
   spec.add_development_dependency "rake"
 end

--- a/oneapi-ruby.gemspec
+++ b/oneapi-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "= 2.5.11"
   spec.add_development_dependency "minitest", "= 5.25.1"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "= 13.2.1"
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
-require 'oneapi/client'
+require 'oneapi-ruby/client'
  
-class OneApiTest < MiniTest::Unit::TestCase
+class OneApiTest < Minitest::Test
 
     def test_empty
         assert_equal OneApi::Utils.empty(0), true


### PR DESCRIPTION
1. Support for `Ruby >= 3.0.0` is added since the official maintainer doesn't appear to have made recent changes to the project. I created this fork because I am facing a discontinuation of support for `Ruby 2.7` on AWS and had to update my application to `Ruby 3.2`.

2. For now, these changes will remain in the `development` branch since there are many other things to fix.

3. Result of the unit test execution:
![image](https://github.com/user-attachments/assets/5d55cd46-2cba-4136-9644-65c09b7de66f)